### PR TITLE
Add cmath lib to fix the compilation error

### DIFF
--- a/src/latency_measurements.hpp
+++ b/src/latency_measurements.hpp
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <cassert>
 #include <algorithm>
+#include <cmath>
 
 /*----------------------------------------------------------------------------*/
 class latency_measurements {
@@ -62,7 +63,7 @@ public:
     {
         assert (m_results.size());
         double step  = ((double) m_results.size()) / 100.;
-        uint64_t idx = (uint64_t) round (step * percentile);
+        uint64_t idx = (uint64_t) std::round (step * percentile);
         /*improvement for small data sets: some type of interpolation*/
         return m_results[std::min (idx, m_results.size() - 1)];
     }


### PR DESCRIPTION
Currently the project fails to build on Ubuntu 18.04 with the following error:
`latency_measurements.hpp:65:40: error: ‘round’ is not a member of ‘std’`

This PR fixes this.